### PR TITLE
fixed #12 편집 페이지 오버플로우 문제 해결

### DIFF
--- a/src/Quill.css
+++ b/src/Quill.css
@@ -1,4 +1,9 @@
+.quill {
+    overflow-y: unset;
+}
+
 .ql-container.ql-snow {
+    overflow-y: scroll;
     border: none !important;
     border-bottom: 1px solid #ccc !important;
 }

--- a/src/blog/EditPostPage.tsx
+++ b/src/blog/EditPostPage.tsx
@@ -204,7 +204,9 @@ const EditPostPage = () => {
 
                     setImages(images => [...images, res])
                     editor.insertEmbed(range.index, "image", getImageUrl(res))
-                    editor.insertText(range.index + 1, "/n")
+                    editor.formatText(0, 1, "width", "100%")
+                    editor.formatText(0, 1, "height", "100%")
+                    editor.insertText(range.index + 2, "\n")
                     editor.setSelection(range.index + 2, 2)
                 })
             )()
@@ -262,7 +264,13 @@ const EditPostPage = () => {
 
     return <>
         <form onSubmit={handleSubmit(onSubmit)}
-              style={{height: "inherit", margin: "30px 80px", paddingTop: "60px"}}>
+              style={{
+                  boxSizing: "border-box",
+                  height: "100%",
+                  margin: "0px 80px",
+                  paddingTop: "60px"
+              }}
+        >
             <Controller name={"title"}
                         control={control}
                         rules={{required: true}}


### PR DESCRIPTION
- **이미지 사이즈 오류**
이미지 업로드 시, 초기 사이즈 지정(100%)

- **텍스트 오버플로우 오류**
사이즈 계산에 border와 margin이 고려되지 않아 발생한 문제
박스 사이즈를 `border-box`로 바꾸고, margin 제거